### PR TITLE
Update Utils.rs

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,7 +94,8 @@ where
         }
         _ => {
             // the below is meant as a light joke.. chill out pls
-            println!("Dunno... Looks Ok but since its not an error i specially check for, here is your result, man... or woman... or they/them");
+            println!("If the error indicating a missing 'data' field means that the 'plan_id' you are using is invalid. Please verify the 'plan_id' on your Paystack dashboard, ensuring it matches either the live or test environment.");
+
             return Ok(res);
         }
     };


### PR DESCRIPTION
Here's a rephrased version of your message:

I’ve updated the error message that appears due to a consistent issue:

```rust
Err(
    reqwest::Error {
        kind: Decode,
        source: Error("missing field `data`", line: 1, column: 219),
    },
)
```

This error always occurs when the wrong `plan_id` is provided. For example, it happens if you're using a live key with a plan from the test environment.

I’ve added instructions to help users easily identify this issue, and I’m opening a pull request with the update.


Let me know if this works!